### PR TITLE
rm: 删除bitblt截屏中不必要的裁切

### DIFF
--- a/source/frame/capture/capture.bitblt.h
+++ b/source/frame/capture/capture.bitblt.h
@@ -78,7 +78,6 @@ namespace tianli::frame::capture
             int nChannels = source_bitmap.bmBitsPixel == 1 ? 1 : source_bitmap.bmBitsPixel / 8;
             this->source_frame.create(cv::Size(source_bitmap.bmWidth, source_bitmap.bmHeight), CV_MAKETYPE(CV_8U, nChannels));
             GetBitmapBits(hbitmap, source_bitmap.bmHeight * source_bitmap.bmWidth * nChannels, this->source_frame.data);
-            this->source_frame = this->source_frame(cv::Rect(client_rect.left, client_rect.top, client_size.width, client_size.height));
             if (this->source_frame.empty())
                 return false;
             if (this->source_frame.cols < 480 || this->source_frame.rows < 360)


### PR DESCRIPTION
实际获得的dc就是client区域的，用rect裁切是在原地tp。

print出来显示也是size一致的。
![image](https://github.com/GengGode/cvAutoTrack/assets/30763045/fb9499a6-454e-4dfd-8f3b-d425e2f4ce0c)
